### PR TITLE
Ensure that we are always listening on the default Broker port.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+tmp
+*.pyc
+.##*
+.cache
+*.swp
+old

--- a/scripts/framework/main.zeek
+++ b/scripts/framework/main.zeek
@@ -75,6 +75,25 @@ export {
 
 	## Interval to broadcast ``hello`` events to all connected agents.
 	option hello_interval = 60 secs;
+
+	## If non-zero and different from the Broker default port, listen this
+	## port for incoming Broker connections.
+	##
+	## Note: Our default here is the same as the Broker default. However,
+	## ZeekControl changes the Broker default based on node type. To still
+	## have a well-known port for agents, we open the port defined here
+	## when the Broker default has been changed. You may also set this to
+	## something entirely different if you want another port for the
+	## agents alltogether.
+	option listen_port = 9999/tcp;
+
+	## Default address on which to listen; empty for any interface, which
+	## is the default.
+	option listen_address = Broker::default_listen_address;
+
+	## Default interval to retry listening on a port if it's currently in
+	## use already.
+	option listen_retry = Broker::default_listen_retry;
 }
 
 # Unique ID for the current Zeek process.
@@ -259,7 +278,9 @@ event zeek_init() &priority=100 {
 }
 
 event zeek_init() &priority=-10 {
-	Broker::listen();
+	if ( listen_port != 0/tcp && listen_port != Broker::default_port )
+		Broker::listen(listen_address, listen_port, listen_retry);
+
 	Broker::subscribe("/zeek-agent/response/all");
 	Broker::subscribe(fmt("/zeek-agent/response/%s/", zeek_instance));
 

--- a/tests/btest.cfg
+++ b/tests/btest.cfg
@@ -6,13 +6,17 @@ IgnoreDirs  = .tmp
 IgnoreFiles = *.tmp *.swp #* *.trace .DS_Store
 
 [environment]
+LC_ALL=C
+PACKAGE=%(testbase)s/../scripts
+PATH=`%(testbase)s/Scripts/get-zeek-env path`
+TEST_DIFF_CANONIFIER=%(testbase)s/Scripts/diff-remove-timestamps
+TMPDIR=%(testbase)s/.tmp
+TRACES=%(testbase)s/Traces
+TZ=UTC
 ZEEKPATH=`%(testbase)s/Scripts/get-zeek-env zeekpath`
+ZEEK_DEFAULT_CONNECT_RETRY=1
+ZEEK_DEFAULT_LISTEN_ADDRESS=127.0.0.1
+ZEEK_DEFAULT_LISTEN_RETRY=1
+ZEEK_DNS_FAKE=1
 ZEEK_PLUGIN_PATH=`%(testbase)s/Scripts/get-zeek-env zeek_plugin_path`
 ZEEK_SEED_FILE=%(testbase)s/Files/random.seed
-PATH=`%(testbase)s/Scripts/get-zeek-env path`
-PACKAGE=%(testbase)s/../scripts
-TZ=UTC
-LC_ALL=C
-TRACES=%(testbase)s/Traces
-TMPDIR=%(testbase)s/.tmp
-TEST_DIFF_CANONIFIER=%(testbase)s/Scripts/diff-remove-timestamps


### PR DESCRIPTION
The cluster framework changes the default based on node type, but our
agents need a known port to connect to. We now open the default port
in addition to the Broker port if the latter changed from the default.
We also allow to set a different port altogether.