### PR TITLE
Extend query API to allow specifying tables that must/must not be pre…

### DIFF
--- a/scripts/framework/types.zeek
+++ b/scripts/framework/types.zeek
@@ -64,6 +64,16 @@ export {
 
 		## Custom cookie string that will be included with results.
 		cookie: string &optional;
+
+		## Specify a set of tables that must be available for this
+		## query to execute. If an agent doesn't have them all, it will
+		## (silently) ignore the query.
+		requires_tables: set[string] &default=set();
+
+		## Specify a set of tables that must *not* be available for this
+		## query to execute. If an agent does have any of them, it will
+		## (silently) ignore the query.
+		if_missing_tables: set[string] &default=set();
 	};
 
 	## Scope that queries apply to.

--- a/scripts/table/system-logs.zeek
+++ b/scripts/table/system-logs.zeek
@@ -38,5 +38,5 @@ event zeek_init() {
 	Log::remove_default_filter(LOG);
 	Log::add_filter(LOG, [$name = "default", $path = "zeek-agent-system-logs", $field_name_map = field_name_map]);
 
-	ZeekAgent::query([$sql_stmt = "SELECT * FROM system_logs_events", $event_ = query_result, $schedule_ = query_interval, $subscription = ZeekAgent::Events]);
+	ZeekAgent::query([$sql_stmt = "SELECT * FROM system_logs_events", $event_ = query_result, $schedule_ = query_interval, $subscription = ZeekAgent::Events, $requires_tables = set("system_logs_events")]);
 }


### PR DESCRIPTION
…sent.

Agents will ignore queries not meeting expectations.

First use case is the system-logs table, which may not be available on
all systems.