### PR TITLE
Change listening default port to 9998.

### DIFF
--- a/scripts/framework/main.zeek
+++ b/scripts/framework/main.zeek
@@ -76,16 +76,12 @@ export {
 	## Interval to broadcast ``hello`` events to all connected agents.
 	option hello_interval = 60 secs;
 
-	## If non-zero and different from the Broker default port, listen this
-	## port for incoming Broker connections.
+	## If non-zero, listen on this port for incoming Broker connections.
 	##
-	## Note: Our default here is the same as the Broker default. However,
-	## ZeekControl changes the Broker default based on node type. To still
-	## have a well-known port for agents, we open the port defined here
-	## when the Broker default has been changed. You may also set this to
-	## something entirely different if you want another port for the
-	## agents alltogether.
-	option listen_port = 9999/tcp;
+	## We use our own port for incoming connections here because
+	## ZeekControl changes the default Broker port based on node type, but
+	## we need a well-known port for the agents to connect to.
+	option listen_port = 9998/tcp;
 
 	## Default address on which to listen; empty for any interface, which
 	## is the default.
@@ -308,7 +304,7 @@ event zeek_init() &priority=100 {
 }
 
 event zeek_init() &priority=-10 {
-	if ( listen_port != 0/tcp && listen_port != Broker::default_port )
+	if ( listen_port != 0/tcp )
 		Broker::listen(listen_address, listen_port, listen_retry);
 
 	Broker::subscribe("/zeek-agent/response/all");


### PR DESCRIPTION
ZeekControl changes Zeek's standard listening port based on node type.
Working around that while keeping port 9999 for the agents is tricky,
so we're now switching to a different port.